### PR TITLE
Add Zeroconf support to allow omxremote to be discovered on the network

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: required
+
+language: go
+
+go:
+  - 1.8.3
+
+install:
+  - make setup
+
+script:
+  - make dev
+  - make test
+  - make release

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ setup:
 	go get github.com/stretchr/testify/assert
 	go get
 
+test:
+	go test ./...
+
 release: clean assets
 	GOOS=linux GOARCH=arm go build
 

--- a/zeroconf.go
+++ b/zeroconf.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"log"
+
+	"github.com/grandcat/zeroconf"
+)
+
+const (
+	zeroConfName    = "omxremote"
+	zeroconfService = "_http._tcp"
+	zeroconfDomain  = "local."
+	zeroconfPort    = 8080
+)
+
+func startZeroConfAdvertisement(stop chan bool) {
+	log.Println("Starting zeroconf:", zeroConfName, zeroconfService, zeroconfPort)
+	defer log.Println("Zeroconf service terminated")
+
+	server, err := zeroconf.Register(
+		zeroConfName,
+		zeroconfService,
+		zeroconfDomain,
+		zeroconfPort,
+		[]string{"version=" + VERSION},
+		nil,
+	)
+	if err != nil {
+		log.Println("Zeroconf server error:", err)
+		return
+	}
+	defer server.Shutdown()
+
+	<-stop
+}


### PR DESCRIPTION
This enabled omxremote to be discoverable via Avahi/Zeroconf as `omxremote._http._tcp` on port 8080.