### PR TITLE
Fix #3: starts zeroconf only if requested

### DIFF
--- a/omxremote.go
+++ b/omxremote.go
@@ -441,8 +441,10 @@ func main() {
 	go omxListen()
 
 	// Start zeroconf service advertisement
-	stopZeroconf := make(chan bool)
-	go startZeroConfAdvertisement(stopZeroconf)
+	if (Zeroconf) {
+		stopZeroconf := make(chan bool)
+		go startZeroConfAdvertisement(stopZeroconf)
+	}
 
 	// Disable debugging mode
 	gin.SetMode("release")


### PR DESCRIPTION
Just add the missing if around the startZeroConfAdvertisement call.

Will fix #3 