### PR TITLE
Fix #4: enable binding on a given IP address

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To start omxremote, run the following command:
 omxremote -media /path/to/media
 ```
 
-Server will start on port 8080 and listen on all network interfaces. You can
+By default server will start on port 8080 and listen on all network interfaces. You can
 connect to it if you have any device (laptop, phone) on the same wifi network.
 If you dont know the IP address of your RPi, run `ifconfig`.
 
@@ -91,6 +91,11 @@ omxremote -media ./ -zeroconf
 ```
 
 Omxremote advertises itself as `omxremote._tcp`
+
+To start the server on a specific interface or a given port, set the HOST and PORT variables.
+```
+HOST=192.168.1.100 PORT=8081 omxremote -media ./
+```
 
 ### Running as daemon
 

--- a/config/omxremote.service
+++ b/config/omxremote.service
@@ -7,6 +7,8 @@ User=pi
 Type=simple
 ExecStart=/usr/bin/omxremote /home/pi/media
 Restart=always
+#Environment=PORT=8081
+#Environment=HOST=192.168.1.100
 
 [Install]
 WantedBy=multi-user.target

--- a/omxremote.go
+++ b/omxremote.go
@@ -469,6 +469,11 @@ func main() {
 		port = "8080"
 	}
 
-	fmt.Println("Starting server on 0.0.0.0:" + port)
-	router.Run(":" + port)
+	host := os.Getenv("HOST")
+	if host == "" {
+		host = "0.0.0.0"
+	}
+
+	fmt.Println("Starting server on " + host + ":" + port)
+	router.Run(host + ":" + port)
 }


### PR DESCRIPTION
Add support for a "HOST" variable to start server on a given address.

Usage: ```HOST=127.0.0.1 ./omxremote /mnt/media/```

Will fix #4 