### PR TITLE
Docs: Improve Build Instructions for iriginal RaspberryPi by referencing correct ARM version

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ In cases if you don't have Make available on your system, you can execute the fo
 
 ```
 go get
-GOOS=linux GOARCH=arm go build
+GOOS=linux GOARCH=arm GOARM=6 go build
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ make release
 ```
 
 That will produce a binary that's ready to be transferred and executed on your RPi. 
-In cases if you dont have Make available on your system, you can execute the following commands:
+In cases if you don't have Make available on your system, you can execute the following commands:
 
 ```
 go get


### PR DESCRIPTION
Some minor tweaks to the readme:
* Fix a small typo
* reference correct arm architecture for original raspberrypi