### PR TITLE
Fix stop command not being sent before page reload

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -345,7 +345,9 @@
 
         $(".stop").on("click", function() {
           command("stop");
-          window.location.reload();
+          setTimeout(function() {
+            window.location.reload();
+          }, 100);
         });
 
         $(".action").on("click", function() {


### PR DESCRIPTION
As mentioned in #14, stop command sometimes doesn't get sent before the page reloads. Adding a timeout between fixes it.