### PR TITLE
Allow setting additional omxplayer options via command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Usage of omxremote:
       Enable frontend applicaiton (default true)
   -media string
       Path to media files (default "./")
+  -omxplay-addn-opts string
+    	Additional command line options for omxplay
   -v  Print version
   -zeroconf
       Enable service advertisement with Zeroconf (default true)

--- a/omx.go
+++ b/omx.go
@@ -74,16 +74,15 @@ func omxInfo(file string) (*FileInfo, error) {
 
 // Start omxplayer playback for a given video file. Returns error if start fails.
 func omxPlay(file string) error {
-	Omx = exec.Command(
-		OmxPath,       // path to omxplayer executable
-		"--stats",     // print stats to stdout (buffers, time, etc)
-		"--with-info", // print stats about streams before playback
-		"--refresh",   // adjust framerate/resolution to video
-		"--blank",     // set background to black
-		"--adev",      // audio out device
-		"hdmi",        // using hdmi for audio/video
-		file,          // path to video file
-	)
+
+	addnopts := strings.Split(OmxAddnOpts, " ")
+	addnopts = append(addnopts, "--stats")      // print stats to stdout (buffers, time, etc)
+	addnopts = append(addnopts, "--with-info")  // print stats about streams before playback
+	addnopts = append(addnopts, "--refresh")    // adjust framerate/resolution to video
+	addnopts = append(addnopts, "--blank")      // set background to black
+	addnopts = append(addnopts, file)
+
+	Omx = exec.Command(OmxPath, addnopts...)
 
 	// Grab child process STDIN
 	stdin, err := Omx.StdinPipe()

--- a/omxremote.go
+++ b/omxremote.go
@@ -69,6 +69,7 @@ var (
 	CurrentFile string         // Currently playing media file name
 	Zeroconf    bool           // Enable Zeroconf discovery
 	Frontend    bool           // Serve frontend app
+	OmxAddnOpts string         // additional options for omxplayer
 	stream      *Stream        // Current stream
 )
 
@@ -300,6 +301,7 @@ func init() {
 	flag.BoolVar(&Frontend, "frontend", true, "Enable frontend applicaiton")
 	flag.BoolVar(&Zeroconf, "zeroconf", true, "Enable service advertisement with Zeroconf")
 	flag.BoolVar(&printVersion, "v", false, "Print version")
+	flag.StringVar(&OmxAddnOpts, "omxplay-addn-opts", "", "Additional command line options for omxplay")
 	flag.Parse()
 
 	if printVersion {


### PR DESCRIPTION
this allows users to specify options to be passed to omxplayer including
the audio device, cache sizing and vsync setting

closes #11